### PR TITLE
Don't queue new devlog updates to airtable

### DIFF
--- a/app/models/devlog.rb
+++ b/app/models/devlog.rb
@@ -156,15 +156,11 @@ class Devlog < ApplicationRecord
   end
 
   def sync_to_airtable
-    return unless Rails.env.production?
-
-    SyncUpdateToAirtableJob.perform_later(id)
+    # SyncUpdateToAirtableJob.perform_later(id)
   end
 
   def delete_from_airtable
-    return unless Rails.env.production?
-
-    DeleteUpdateFromAirtableJob.perform_later(id)
+    # DeleteUpdateFromAirtableJob.perform_later(id)
   end
 
   def notify_followers_and_stakers


### PR DESCRIPTION
![Screenshot 2025-06-24 at 00 49 13](https://github.com/user-attachments/assets/542b21de-a961-4592-9e01-7118fdaeca51)

These jobs have been erroring for a while now. Turning off queueing of more for the time being.