### PR TITLE
Add flipper flagging for voting

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -5,7 +5,7 @@ class VotesController < ApplicationController
   before_action :set_projects, only: %i[new]
   before_action :check_identity_verification
 
-  before_action :redirect_to_locked, except: [ :locked ], unless: -> { current_user&.is_admin? }
+  before_action :redirect_to_locked, except: [ :locked ], unless: -> { current_user&.can_vote? }
 
   def new
     @vote = Vote.new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -232,6 +232,10 @@ class User < ApplicationRecord
     staked_projects.distinct.count < 5
   end
 
+  def can_vote?
+    is_admin? || Flipper.enabled?("2025_06_28_voting", self)
+  end
+
   def staked_projects_count
     staked_projects.distinct.count
   end


### PR DESCRIPTION
This is temporary to allow users to try out the voting system. Want to let someone into the voting system?

```rb
user = User.find_by_slack_id('U054VC2KM9P')
Flipper.enable_actor "2025_06_28_voting", user
```