### PR TITLE
Clarify banner requirement when shipping.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -300,7 +300,7 @@ class Project < ApplicationRecord
       },
       banner: {
         met: banner.present?,
-        message: if !banner.present? && (devlogs.find { |u| u.file.attached? && u.file.image? }&.file).present? then "Project must have a banner image (not from a Devlog)." else "Project must have a banner image." end
+        message: "Project must have a banner image (not from a Devlog)."
       },
       previous_payout: {
         met: latest_ship_certification&.rejected? || unpaid_ship_events_since_last_payout.empty?,


### PR DESCRIPTION
The current behaviour for a project without a banner is to use an image from the project's devlog.

From a user's perspective, there is a banner uploaded to the project, but this "banner" does not count towards the shipping requirements. The user is stuck until they upload a banner to the project, which is not prompted.

This PR edits the shipping requirement message when the user has a "banner" from devlogs but has not actually uploaded a banner

<img width="300" alt="Screenshot 2025-07-21 at 12 06 16 PM" src="https://github.com/user-attachments/assets/48661a8a-d5e2-46a8-a5e1-4b340a111b95" />