### PR TITLE
Remove newline regex

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -24,7 +24,6 @@ module MarkdownHelper
     return "" if text.blank?
 
     text = text.gsub(/(?<!~)~(?!~)(.*?)(?<!~)~(?!~)/, '~~\1~~')
-    text = text.gsub(/\n{2,}/, "\n<br>\n")
 
     markdown = Redcarpet::Markdown.new(
       CustomRender.new(


### PR DESCRIPTION
Lets redcarpet collapse newlines automatically instead of mangling the output with a bunch of `<br>`s 