### PR TITLE
Add better styling to the View Orders button

### DIFF
--- a/app/views/shop_items/index.html.erb
+++ b/app/views/shop_items/index.html.erb
@@ -20,9 +20,9 @@
     <div class="justify-center flex">
       <%= render "verification_callout" unless current_verification_status == :verified %>
     </div>
-    <div class="justify-center flex mt-4">
-      <%= link_to "View My Orders", shop_orders_path, class: "bg-black text-white px-6 py-3 rounded-lg font-semibold text-lg hover:bg-gray-800 transition-all duration-200" %>
-    </div>
+  <div class="justify-center flex mt-4">
+    <%= link_to "View My Orders", shop_orders_path, class: "bg-[#D8BFA7] text-black px-6 py-3 rounded-lg font-semibold text-lg shadow-md hover:shadow-lg hover:bg-[#cdb196] transition-all duration-200" %>
+  </div>
   <% end %>
 
   <% if @regionalization_enabled %>


### PR DESCRIPTION
The previous styling for the "View My Orders" button felt a bit off-brand and didn’t visually align with the rest of the UI. I updated it with a more cohesive background color (#D8BFA7) and added a subtle shadow to give it a more modern, elevated look.

P.S. Apologies for the duplicate PRs earlier, since I ran into some branch conflicts and had to untangle the mess. All good now!

