### PR TITLE
Fix view orders button to use primary button theme

### DIFF
--- a/app/views/shop_items/index.html.erb
+++ b/app/views/shop_items/index.html.erb
@@ -20,9 +20,13 @@
     <div class="justify-center flex">
       <%= render "verification_callout" unless current_verification_status == :verified %>
     </div>
-    <div class="justify-center flex mt-4">
-      <%= link_to "View My Orders", shop_orders_path, class: "bg-black text-white px-6 py-3 rounded-lg font-semibold text-lg hover:bg-gray-800 transition-all duration-200" %>
-    </div>
+    <%= render "shared/button",
+      text: "View My Orders",
+      link: shop_orders_path,
+      kind: :primary,
+      fill_width: false,
+      icon: nil
+    %>
   <% end %>
 
   <% if @regionalization_enabled %>


### PR DESCRIPTION
Updated the "View My Orders" button to use the shared button partial for consistent styling and proper theming across the site.