### PR TITLE
Fix some major typos

### DIFF
--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -476,8 +476,8 @@
           <div class="p-1 md:p-3 relative">
             <h3 class="font-['DynaPuff'] font-bold text-lg md:text-xl text-[#8B4513] mb-2 md:mb-3 z-10">Who is eligible?</h3>
             <p class="font-['Fredoka'] font-normal text-base md:text-lg text-[#3a2f25] z-10">
-              You need to be a high schooler (or younger). If you are over 18. you can participate in our
-              <a href="https://docs.google.com/document/d/1xiAoYrO6wY1knzZhI1TFYVqCo6q2R7A46he0w5tan90/edit?usp=sharing" target="_blank" rel="noopener noreferrer" class="text-som-orange underline hover:text-[#d14c26] transition-colors font-semibold">referral program</a> and earn prizes by getting teens exited about building cool stuff.
+              You need to be a high schooler (or younger). If you are over 18, you can participate in our
+              <a href="https://docs.google.com/document/d/1xiAoYrO6wY1knzZhI1TFYVqCo6q2R7A46he0w5tan90/edit?usp=sharing" target="_blank" rel="noopener noreferrer" class="text-som-orange underline hover:text-[#d14c26] transition-colors font-semibold">referral program</a> and earn prizes by getting teens excited about building cool stuff.
             </p>
           </div>
         <% end %>


### PR DESCRIPTION
Fix some major typos such as using "exited" instead of "excited" and a period instead of a comma after 18 and before you. Both of these typos were in the "Who is eligible?" section.