### PR TITLE
Fix the long View Orders button

### DIFF
--- a/app/views/shop_items/index.html.erb
+++ b/app/views/shop_items/index.html.erb
@@ -20,13 +20,15 @@
     <div class="justify-center flex">
       <%= render "verification_callout" unless current_verification_status == :verified %>
     </div>
-    <%= render "shared/button",
-      text: "View My Orders",
-      link: shop_orders_path,
-      kind: :primary,
-      fill_width: false,
-      icon: nil
-    %>
+    <div class="mt-1 inline-block w-auto">
+      <%= render "shared/button",
+        text: "View My Orders",
+        link: shop_orders_path,
+        kind: :primary,
+        fill_width: false,
+        icon: nil
+      %>
+    </div>
   <% end %>
 
   <% if @regionalization_enabled %>


### PR DESCRIPTION
The view orders button is very long and also bumps into the shop text, so this should fix both by adding spacing and using w-auto to decrease the width to match the size of the text.