### PR TITLE
Fix the mobile navigation being cut off most of the time

### DIFF
--- a/app/views/comments/_modal.html.erb
+++ b/app/views/comments/_modal.html.erb
@@ -1,5 +1,5 @@
 <!-- Comment Modal -->
-<div class="modal hidden fixed inset-0 z-50 overflow-auto bg-black/30 flex items-center justify-center p-2 md:p-4 min-h-screen min-w-screen" id="comment-modal-<%= devlog.id %>" data-controller="modal comment-modal">
+<div class="modal hidden fixed inset-0 z-50 overflow-auto bg-black/30 flex items-center justify-center p-2 md:p-4 min-h-[100dvh] min-w-screen" id="comment-modal-<%= devlog.id %>" data-controller="modal comment-modal">
   <div class="bg-[#F3ECD8] rounded-2xl border-4 border-[#E4DCC6] w-full max-w-2xl mx-2 md:mx-auto relative" data-modal-target="container">
     <div class="p-3 md:p-4 border-b border-saddle-taupe border-opacity-30">
       <div class="flex justify-between items-center">

--- a/app/views/devlogs/_edit_modal.html.erb
+++ b/app/views/devlogs/_edit_modal.html.erb
@@ -1,5 +1,5 @@
 <!-- Edit Modal for Devlogs -->
-<div class="modal hidden fixed inset-0 z-50 overflow-auto bg-black/30 flex items-center justify-center p-2 md:p-4 min-h-screen" id="edit-modal-<%= devlog.id %>" data-controller="modal edit-modal">
+<div class="modal hidden fixed inset-0 z-50 overflow-auto bg-black/30 flex items-center justify-center p-2 md:p-4 min-h-[100dvh]" id="edit-modal-<%= devlog.id %>" data-controller="modal edit-modal">
   <div class="bg-[#F3ECD8] rounded-2xl border-4 border-[#E4DCC6] w-full max-w-2xl mx-2 md:mx-auto relative" data-modal-target="container">
     <div class="p-3 md:p-4 border-b border-saddle-taupe border-opacity-30">
       <div class="flex justify-between items-center">

--- a/app/views/errors/internal_server.html.erb
+++ b/app/views/errors/internal_server.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center items-center h-screen">
+<div class="flex justify-center items-center h-[100dvh]">
   <div class="bg-vintage-red bg-opacity-30 backdrop-blur-lg p-8 rounded-xl shadow-lg text-center max-w-2xl">
     <h1 class="text-2xl font-bold mb-4">500 Internal Server Error!</h1>
     <p class="text-lg">Something went wrong on our end, we are aware of this and are working to fix it. Please try again later! If you're still having issues after a while, try asking in #summer-of-making-help</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center items-center h-screen">
+<div class="flex justify-center items-center h-[100dvh]">
   <div class="bg-vintage-red bg-opacity-30 backdrop-blur-lg p-8 rounded-xl shadow-lg text-center max-w-2xl">
     <h1 class="text-2xl font-bold mb-4">404 Not Found!</h1>
     <p class="text-lg">We can't find the page you're looking for... try using the sidebar to get to where you need. If you expected something different to be here, try asking in #summer-of-making-help</p>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -5,7 +5,7 @@
 <div class="relative w-full mb-[10vh]">
   <%= inline_svg "parchment.svg" %>
 
-  <div class="relative w-full min-h-screen">
+  <div class="relative w-full min-h-[100dvh]">
     <div class="font-['Fredoka',sans-serif] leading-normal w-full relative overflow-hidden" data-controller="smooth-scroll">
       <div class="absolute top-0 left-4 z-20">
         <%= image_tag "flag-orpheus-top.png", alt: "Island", class: "w-36" %>
@@ -20,7 +20,7 @@
         </a>
       </div>
 
-      <div class="relative z-15 flex items-center min-h-screen">
+      <div class="relative z-15 flex items-center min-h-[100dvh]">
         <div class="w-full mt-18 mb-18 max-w-6xl mx-auto px-4 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-6 items-center">
           <div class="flex flex-col text-left gap-4 animate-float mt-12 lg:mt-0 lg:pr-6 items-center" style="font-family: 'Pacifico', sans-serif;">
             <%= image_tag "logo_text.png", alt: "Logo Text", class: "mb-2 w-96 sm:w-120" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
     <% end %>
   </head>
 
-  <body class="min-h-screen font-national-park font-bold text-som-dark">
+  <body class="min-h-[100dvh] font-national-park font-bold text-som-dark">
     <%# admin_tool do %>
       <%# render "shared/stonk_tickler_marquee" %>
     <%# end %>
@@ -76,7 +76,7 @@
         <% else %>
           <div data-controller="sidebar" data-sidebar-collapsed-value="false">
             <% if mobile_device? %>
-              <div class="flex flex-col h-screen box-border p-0">
+              <div class="flex flex-col h-[100dvh] box-border p-0">
                 <main class="py-4 px-0 sm:px-4 overflow-y-scroll flex-grow flex-shrink">
                   <div id="flash-container">
                     <%= render "shared/flash" %>
@@ -86,7 +86,7 @@
                 <%= render "shared/mobile_nav" %>
               </div>
             <% else %>
-              <div class="flex flex-col h-screen box-border p-0">
+              <div class="flex flex-col h-[100dvh] box-border p-0">
                 <% if !current_user.has_hackatime? && !current_user.tutorial_progress.completed_at.nil? %>
                   <div class="w-full bg-vintage-red text-white flex flex-col justify-center py-2">
                     <p class="text-center">

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="min-h-screen">
+<html class="min-h-[100dvh]">
   <head>
     <title><%= content_for(:title) || "Journey" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -16,7 +16,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="min-h-screen bg-warm tracking-wider flex flex-col items-center justify-center">
+  <body class="min-h-[100dvh] bg-warm tracking-wider flex flex-col items-center justify-center">
     <div class="w-full max-w-2xl">
       <%= yield %>
     </div>

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -4,7 +4,7 @@
      data-map-update-url-value="<%= update_coordinates_project_path(':id') %>"
      data-map-map-points-url-value="<%= map_points_path %>"
      data-map-unplace-url-value="<%= unplace_coordinates_project_path(':id') %>"
-     class="relative w-screen h-screen overflow-hidden bg-[#41A5E7]">
+     class="relative w-screen h-[100dvh] overflow-hidden bg-[#41A5E7]">
   <div class="absolute inset-0 bg-[url('/map_sea_background.jpg')] bg-cover bg-center opacity-28 pointer-events-none z-0"></div>
 
   <div data-map-target="canvas"

--- a/app/views/shared/_error_layout.html.erb
+++ b/app/views/shared/_error_layout.html.erb
@@ -6,7 +6,7 @@
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>
-<body class="bg-bread min-h-screen flex flex-col items-center justify-center">
+<body class="bg-bread min-h-[100dvh] flex flex-col items-center justify-center">
   <div class="bg-warm w-full text-center">
     <div class="mb-6 w-64 h-64 lg:w-96 lg:h-96 2xl:h-128 2xl:w-128 mx-auto">
       <%= yield(:mascot) %>

--- a/app/views/static_pages/gork.html.erb
+++ b/app/views/static_pages/gork.html.erb
@@ -3,7 +3,7 @@
   <%= javascript_include_tag "gork/elizadata" %>
 <% end %>
 
-<div class="min-h-screen flex flex-col text-[#3a2f25] overflow-none">
+<div class="min-h-[100dvh] flex flex-col text-[#3a2f25] overflow-none">
   <!-- Header -->
   <div class=" mx-4 mt-4 px-4 py-3 flex items-center sticky top-4 z-10">
     <div class="flex items-center space-x-3">


### PR DESCRIPTION
You may have noticed that on mobile, part of the bottom (mobile-only) navigation bar gets cut off until you scroll all the way down. This PR fixes that issue!

| Before | After |
|--|--|
|![](https://github.com/user-attachments/assets/212722a6-5727-43a7-b581-b6b015a59e67)| ![](https://github.com/user-attachments/assets/42e5768f-7df1-4ddc-8ddf-437335fdac69)

### Cause of the problem

It happens because we set `min-h-screen` on the `<body>` (and other elements), which sets `min-height: 100vh`. However, on most mobile browsers, `100vh` is equivalent to the height of the _expanded_ viewport (i.e. with some viewport elements collapsed). This means that a lot of the time the page extends past the actual viewport size, causing the bottom nav to be cut off.

### The fix

I fixed this by simply replacing any instances of the `h-screen` and `min-h-screen` with `h-[100dvh]` and `min-h-[100dvh]` respectively. This uses the [dynamic viewport height](https://web.dev/blog/viewport-units) unit.

I didn't have to change it everywhere to fix the bug, but I did so to ensure consistent usage of CSS units.

### Alternatives

An alternative would be to create our own `h-screen` and `min-h-screen` utility classes (in a CSS file or in Tailwind config) that uses `100dvh` instead of `100vh`. I decided to go for the simplest fix to the problem, but I can create a utility class to solve the problem instead, if desired.

### Drawbacks

I'm not sure what the browser support policy for Summer of Making is, but the `dvh` unit is supported by the following browsers: <https://caniuse.com/mdn-css_types_length_viewport_percentage_units_dynamic> (TLDR: any browser version released after Nov 2022 onwards)

If browser support is a concern, I can instead create a utility class that gracefully degrades to the `vh` unit if `dvh` isn't supported.