### PR TITLE
Fix extremely long "View Orders" button

### DIFF
--- a/app/views/shop_items/index.html.erb
+++ b/app/views/shop_items/index.html.erb
@@ -20,7 +20,7 @@
     <div class="justify-center flex">
       <%= render "verification_callout" unless current_verification_status == :verified %>
     </div>
-    <div class="mt-1 inline-block w-auto">
+    <div class="justify-center flex py-2">
       <%= render "shared/button",
         text: "View My Orders",
         link: shop_orders_path,


### PR DESCRIPTION
I gave the view orders button a width of 40 and added some padding so it doesn't interfere with the text above.