### PR TITLE
Make API routes more functional for third-party applications.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,3 +165,6 @@ gem "sanitize", "~> 7.0"
 gem "activeinsights"
 
 gem "paper_trail"
+
+# Use rack-cors to configure CORS to be inactive on API routes
+gem "rack-cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,6 +423,9 @@ GEM
     rack (3.1.16)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-mini-profiler (4.0.0)
       rack (>= 1.2.0)
     rack-protection (4.1.1)
@@ -693,6 +696,7 @@ DEPENDENCIES
   puma (>= 5.0)
   pundit (~> 2.5)
   rack-attack (~> 6.7)
+  rack-cors
   rack-mini-profiler
   rails (~> 8.0.2)
   rails_live_reload

--- a/app/controllers/api/v1/votes_controller.rb
+++ b/app/controllers/api/v1/votes_controller.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class VotesController < ApplicationController
+      before_action :authenticate_user!
+      before_action :set_projects, only: %i[new]
+      before_action :check_identity_verification
+
+      # GET /api/v1/votes/new
+      def new
+        @vote = Vote.new
+        @submitted_votes_count = current_user.votes.count
+        set_projects
+
+        if @projects.size < 2
+          render json: { error: "Not enough projects available to vote on." }, status: :unprocessable_entity
+          return
+        end
+
+        puts "current ids", @ship_events.map(&:id)
+
+        render json: {
+          vote_signature: @vote_signature,
+          projects: @projects.map.with_index do |project, i|
+            ship_event = @ship_events[i]
+            devlogs = project.devlogs.where("created_at < ?", ship_event.created_at).order(created_at: :asc)
+            ship_time_seconds = devlogs.sum(:duration_seconds)
+            {
+              id: project.id,
+              title: project.title,
+              banner: project.banner.attached? ? url_for(project.banner) : nil,
+              demo_link: project.demo_link,
+              repo_link: project.repo_link,
+              used_ai: @project_ai_used[project.id],
+              time_spent: ship_time_seconds,
+              devlogs: devlogs.map do |devlog|
+                {
+                  id: devlog.id,
+                  text: devlog.text,
+                  duration_seconds: devlog.duration_seconds,
+                  created_at: devlog.created_at,
+                  user: {
+                    id: devlog.user.id,
+                    display_name: devlog.user.display_name,
+                    avatar_url: devlog.user.avatar
+                  },
+                  file_url: devlog.file.attached? ? url_for(devlog.file) : nil,
+                  file_type: devlog.file.attached? ? devlog.file.content_type : nil
+                }
+              end
+            }
+          end,
+          ship_event_ids: @ship_events.map(&:id)
+        }
+      end
+
+      def create
+        @vote = current_user.votes.build(vote_params)
+
+        if @vote[:explanation].length < 10
+          render json: { error: "Explanation must be at least 10 characters if provided." }, status: :unprocessable_entity
+          return
+        end
+
+        winning_project_id = params[:winning_project_id]
+        if winning_project_id == "tie"
+          @vote.winning_project_id = nil
+        else
+          @vote.winning_project_id = winning_project_id
+        end
+
+        unless VoteSignatureService.verify_signature_with_ship_events(
+          params[:vote_signature],
+          params[:ship_event_1_id].to_i,
+          params[:ship_event_2_id].to_i,
+          current_user.id
+        )[:valid]
+          render json: { error: "Invalid vote information" }, status: :unprocessable_entity
+          return
+        end
+
+        if @vote.save
+          render json: { success: true }, status: :created
+        else
+          render json: { errors: @vote.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def vote_params
+        params.permit(
+          :project_1_id,
+          :project_2_id,
+          :ship_event_1_id,
+          :ship_event_2_id,
+          :explanation,
+          :winning_project_id,
+          :project_1_demo_opened,
+          :project_1_repo_opened,
+          :project_2_demo_opened,
+          :project_2_repo_opened,
+          :time_spent_voting_ms,
+          :music_played
+        )
+      end
+
+      def check_identity_verification
+        return if current_user.identity_vault_id.present? && current_user.verification_status != :ineligible
+
+        render json: { error: "Identity verification required" }, status: :forbidden
+      end
+
+      def set_projects
+        # Get projects that haven't been voted on by current user
+        voted_ship_event_ids = current_user.votes
+                                          .joins(vote_changes: { project: :ship_events })
+                                          .distinct
+                                          .pluck("ship_events.id")
+
+        projects_with_latest_ship = Project
+                                      .joins(:ship_events)
+                                      .joins(:ship_certifications)
+                                      .includes(ship_events: :payouts)
+                                      .where(ship_certifications: { judgement: :approved })
+                                      .where.not(user_id: current_user.id)
+                                      .where(
+                                        ship_events: {
+                                          id: ShipEvent.select("MAX(ship_events.id)")
+                                                      .where("ship_events.project_id = projects.id")
+                                                      .group("ship_events.project_id")
+                                                      .where.not(id: voted_ship_event_ids)
+                                        }
+                                      )
+                                      .distinct
+
+        if projects_with_latest_ship.count < 2
+          @projects = []
+          return
+        end
+
+        eligible_projects = projects_with_latest_ship.to_a
+
+        latest_ship_event_ids = eligible_projects.map { |project|
+          project.ship_events.max_by(&:created_at).id
+        }
+
+        total_times_by_ship_event = Devlog
+          .joins("INNER JOIN ship_events ON devlogs.project_id = ship_events.project_id")
+          .where(ship_events: { id: latest_ship_event_ids })
+          .where("devlogs.created_at <= ship_events.created_at")
+          .group("ship_events.id")
+          .sum(:duration_seconds)
+
+        projects_with_time = eligible_projects.map do |project|
+          latest_ship_event = project.ship_events.max_by(&:created_at)
+          total_time_seconds = total_times_by_ship_event[latest_ship_event.id] || 0
+          is_paid = latest_ship_event.payouts.any?
+
+          {
+            project: project,
+            total_time: total_time_seconds,
+            ship_event: latest_ship_event,
+            is_paid: is_paid,
+            ship_date: latest_ship_event.created_at
+          }
+        end
+
+        projects_with_time = projects_with_time.select { |p| p[:total_time] > 0 }
+
+        # sort by ship date – disabled until genesis
+        projects_with_time.sort_by! { |p| p[:ship_date] }
+
+        unpaid_projects = projects_with_time.select { |p| !p[:is_paid] }
+        paid_projects = projects_with_time.select { |p| p[:is_paid] }
+
+        # we need at least 1 unpaid project and 1 other project (status doesn't matter)
+        if unpaid_projects.empty? || projects_with_time.size < 2
+          @projects = []
+          return
+        end
+
+        selected_projects = []
+        selected_project_data = []
+        used_user_ids = Set.new
+        used_repo_links = Set.new
+        max_attempts = 25 # infinite loop!
+
+        attempts = 0
+        # TODO: change to weighted_sample after genesis
+        while selected_projects.size < 2 && attempts < max_attempts
+          attempts += 1
+
+          # pick a random unpaid project first
+          if selected_projects.empty?
+            available_unpaid = unpaid_projects.select { |p| !used_user_ids.include?(p[:project].user_id) && !used_repo_links.include?(p[:project].repo_link) }
+            first_project_data = weighted_sample(available_unpaid)
+            next unless first_project_data
+
+            selected_projects << first_project_data[:project]
+            selected_project_data << first_project_data
+            used_user_ids << first_project_data[:project].user_id
+            used_repo_links << first_project_data[:project].repo_link if first_project_data[:project].repo_link.present?
+            first_time = first_project_data[:total_time]
+
+            # find projects within the constraints (set to 30%)
+            min_time = first_time * 0.7
+            max_time = first_time * 1.3
+
+            compatible_projects = projects_with_time.select do |p|
+              !used_user_ids.include?(p[:project].user_id) &&
+              !used_repo_links.include?(p[:project].repo_link) &&
+              p[:total_time] >= min_time &&
+              p[:total_time] <= max_time
+            end
+
+            if compatible_projects.any?
+              second_project_data = weighted_sample(compatible_projects)
+              selected_projects << second_project_data[:project]
+              selected_project_data << second_project_data
+              used_user_ids << second_project_data[:project].user_id
+              used_repo_links << second_project_data[:project].repo_link if second_project_data[:project].repo_link.present?
+            else
+              selected_projects.clear
+              selected_project_data.clear
+              used_user_ids.clear
+              used_repo_links.clear
+            end
+          end
+        end
+
+        # js getting smtth if after 25 attemps we have nothing
+        if selected_projects.size < 2 && unpaid_projects.any?
+          first_project_data = weighted_sample(unpaid_projects)
+          remaining_projects = projects_with_time.reject { |p|
+            p[:project].user_id == first_project_data[:project].user_id ||
+            (p[:project].repo_link.present? && p[:project].repo_link == first_project_data[:project].repo_link)
+          }
+
+          if remaining_projects.any?
+            second_project_data = weighted_sample(remaining_projects)
+            selected_projects = [ first_project_data[:project], second_project_data[:project] ]
+            selected_project_data = [ first_project_data, second_project_data ]
+          end
+        end
+
+        if selected_projects.size < 2
+          @projects = []
+          return
+        end
+
+        # load what we need
+        selected_project_ids = selected_projects.map(&:id)
+        @projects = Project
+                    .includes(:banner_attachment,
+                              :ship_certifications,
+                              ship_events: :payouts,
+                              devlogs: [ :user, :file_attachment ])
+                    .where(id: selected_project_ids)
+                    .index_by(&:id)
+                    .values_at(*selected_project_ids)
+
+        @ship_events = selected_project_data.map { |data| data[:ship_event] }
+
+        @project_ai_used = {}
+        @projects.each do |project|
+          ai_used = if project.respond_to?(:ai_used?)
+            project.ai_used?
+          elsif project.ship_certifications.loaded? && project.ship_certifications.any? { |cert| cert.respond_to?(:ai_used?) }
+            latest_cert = project.ship_certifications.max_by(&:created_at)
+            latest_cert&.ai_used? || false
+          else
+            false
+          end
+          @project_ai_used[project.id] = ai_used
+        end
+
+        if @ship_events.size == 2
+          @vote_signature = VoteSignatureService.generate_signature(
+            @ship_events[0].id,
+            @ship_events[1].id,
+            current_user.id
+          )
+        end
+      end
+      def weighted_sample(projects)
+        return nil if projects.empty?
+        return projects.first if projects.size == 1
+
+        # Create weights where earlier projects (index 0) have higher weight
+        # Weight decreases exponentially: first project gets weight 1.0, second gets 0.95, third gets 0.90, etc.
+        weights = projects.map.with_index { |_, index| 0.95 ** index }
+        total_weight = weights.sum
+
+        # Generate random number between 0 and total_weight
+        random = rand * total_weight
+
+        # Find the project corresponding to this random weight
+        cumulative_weight = 0
+        projects.each_with_index do |project, index|
+          cumulative_weight += weights[index]
+          return project if random <= cumulative_weight
+        end
+
+        # Fallback (should never reach here)
+        projects.first
+      end
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -136,4 +136,30 @@ class SessionsController < ApplicationController
     session[:impersonator_user_id] = nil
     redirect_to root_path, notice: "welcome back, 007!"
   end
+
+  # You need to be authenticated so it can just return the session state for the
+  # API to use.
+  def api_login
+    if params[:redirect_uri]
+      begin
+        @redirect_uri = URI.parse(params[:redirect_uri])
+      rescue URI::InvalidURIError
+        render :api_login_error
+      end
+    else
+      render :api_login_error
+    end
+  end
+
+  # This just sends the session cookie so it can be used for auth.
+  def api_redirect
+    if params[:redirect_uri]
+      uri = URI.parse(params[:redirect_uri])
+      existing_params = Rack::Utils.parse_nested_query(uri.query)
+      uri.query = existing_params.merge({ _journey_session: cookies["_journey_session"] }).to_query
+      redirect_to uri.to_s
+    else
+      render :api_login_error
+    end
+  end
 end

--- a/app/views/sessions/api_login.html.erb
+++ b/app/views/sessions/api_login.html.erb
@@ -1,0 +1,35 @@
+<%# <div class="px-4 md:px-8 max-w-2xl mx-auto mt-12">
+  <div class="bg-white rounded-xl shadow-lg p-8 border border-gray-200">
+    
+  </div>
+</div> %>
+
+<div class="w-full h-full grid place-items-center p-5 lg:m-0">
+  <%= render "shared/card", classes: "w-full lg:w-2/5 mx-auto" do %>
+    <div class="flex items-center gap-3 mb-4">
+      <div class="w-10 h-10 rounded-lg flex items-center justify-center">
+        <%= inline_svg "slack.svg", class: "w-10 h-10 text-white" %>
+      </div>
+      <h1 class="text-2xl font-bold text-gray-900">Third-party Application Login</h1>
+    </div>
+    <p class="mb-4 text-gray-700">
+      You are about to log into Summer of Making through a third-party client. This will allow
+      the client to access your Summer of Making data and perform actions on your behalf. Ensure the
+      application you are using is trustable and that you understand the permissions it is requesting.
+    </p>
+
+    <p class="mb-4 flex flex-col gap-2 text-gray-700">
+      <b class="text-black">URL: <%= @redirect_uri %></b> 
+      <span>Make sure the URL is correct and matches with the application you will be using.</span>
+    </p>
+
+    <div class="">
+      <div class="flex flex-row items-center gap-4">
+        <button onClick="window.open('/auth/apiredirect?redirect_uri=<%= @redirect_uri %>', '_self')" class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+          Yes, continue to the application.
+        </button>
+        <a href="/" class="text-blue-600 hover:text-blue-700 underline">No, take me back</a>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/sessions/api_login.html.erb
+++ b/app/views/sessions/api_login.html.erb
@@ -1,6 +1,6 @@
 <%# <div class="px-4 md:px-8 max-w-2xl mx-auto mt-12">
   <div class="bg-white rounded-xl shadow-lg p-8 border border-gray-200">
-    
+
   </div>
 </div> %>
 
@@ -19,7 +19,7 @@
     </p>
 
     <p class="mb-4 flex flex-col gap-2 text-gray-700">
-      <b class="text-black">URL: <%= @redirect_uri %></b> 
+      <b class="text-black">URL: <%= @redirect_uri %></b>
       <span>Make sure the URL is correct and matches with the application you will be using.</span>
     </p>
 

--- a/app/views/sessions/api_login_error.html.erb
+++ b/app/views/sessions/api_login_error.html.erb
@@ -1,0 +1,6 @@
+<div class="flex justify-center items-center h-[100dvh]">
+  <div class="bg-vintage-red bg-opacity-30 backdrop-blur-lg p-8 rounded-xl shadow-lg text-center max-w-2xl">
+    <h1 class="text-2xl font-bold mb-4">Invalid Application Authentication Request!</h1>
+    <p class="text-lg">The service that sent you here seems to have made a malformed request. You should ask them for support.</p>
+  </div>
+</div>

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,15 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    # Allow requests from secure origins for prod, localhost for dev
+    origins lambda { |origin, _env|
+      origin =~ %r{\Ahttp://localhost:\d+\z} ||
+      origin =~ %r{\Ahttps://.*\z}
+    }
+    resource "/api/*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
+      credentials: true
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@
 #                               auth_slack GET    /auth/slack(.:format)                                                                             sessions#new
 #                           slack_callback GET    /auth/slack/callback(.:format)                                                                    sessions#create
 #                             auth_failure GET    /auth/failure(.:format)                                                                           sessions#failure
+#                            auth_apilogin GET    /auth/apilogin(.:format)                                                                          sessions#api_login
+#                         auth_apiredirect GET    /auth/apiredirect(.:format)                                                                       sessions#api_redirect
 #                                   logout DELETE /logout(.:format)                                                                                 sessions#destroy
 #                               magic_link GET    /magic-link(.:format)                                                                             sessions#magic_link
 #                  identity_vault_callback GET    /users/identity_vault_callback(.:format)                                                          users#identity_vault_callback
@@ -204,6 +206,8 @@ Rails.application.routes.draw do
   get "/auth/slack", to: "sessions#new"
   get "/auth/slack/callback", to: "sessions#create", as: :slack_callback
   get "/auth/failure", to: "sessions#failure"
+  get "/auth/apilogin", to: "sessions#api_login"
+  get "/auth/apiredirect", to: "sessions#api_redirect"
   delete "/logout", to: "sessions#destroy", as: :logout
   delete "/stop_impersonating", to: "sessions#stop_impersonating", as: :stop_impersonating
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,6 +315,7 @@ Rails.application.routes.draw do
       resources :devlogs, only: [ :index, :show ]
       resources :comments, only: [ :index, :show ]
       resources :emotes, only: [ :show ]
+      resources :votes, only: [ :new, :create ]
     end
   end
   get "api/check_user", to: "users#check_user"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@
 #                                  devlogs GET    /devlogs(.:format)                                                                                devlogs#index
 #                                    votes POST   /votes(.:format)                                                                                  votes#create
 #                                 new_vote GET    /votes/new(.:format)                                                                              votes#new
-#                               shop_item POST   /shop_item(.:format)                                                                             shop_item#create
+#                               shop_item POST    /shop_item(.:format)                                                                             shop_item#create
 #                            new_shop_item GET    /shop_item/new(.:format)                                                                         shop_item#new
 #                           edit_shop_item GET    /shop_item/:id/edit(.:format)                                                                    shop_item#edit
 #                                shop_item GET    /shop_item/:id(.:format)                                                                         shop_item#show
@@ -81,6 +81,8 @@
 #                          api_v1_comments GET    /api/v1/comments(.:format)                                                                        api/v1/comments#index
 #                           api_v1_comment GET    /api/v1/comments/:id(.:format)                                                                    api/v1/comments#show
 #                             api_v1_emote GET    /api/v1/emotes/:id(.:format)                                                                      api/v1/emotes#show
+#                         api_v1_votes_new GET    /api/v1/votes/new(.:format)                                                                       api/v1/votes#new
+#                      api_v1_votes_create POST   /api/v1/votes(.:format)                                                                           api/v1/votes#create
 #                           api_check_user GET    /api/check_user(.:format)                                                                         users#check_user
 #                              api_devlogs POST   /api/devlogs(.:format)                                                                            devlogs#api_create
 #      users_update_hackatime_confirmation POST   /users/update_hackatime_confirmation(.:format)                                                    users#update_hackatime_confirmation


### PR DESCRIPTION
This pull request is to expand the functionality of the Summer of Making API, such that third-party applications can access, authenticate, and interact with the main server.

Commits, purpose, and side-notes
- `Remove CORS for API routes`
  - This adds a gem, `rack-cors`, and configures it to allow secure origins (`https://*.*`) and localhost (`http://localhost:*`) on all API routes.
- `Add auth flow for API clients`
  - Adds two handlers on `/auth/apilogin` and `/auth/apiredirect`.
  - `auth_apilogin` presents the currently logged in user with a confirmation dialog, making sure they want to log into a third-party application and warning them of the risks.
  - `auth_apiredirect` redirects the user back to the third-party application, placing the current session ID in query parametres.
  - **Side-note**: Third-party applications share a session ID with the main client to prevent an invasive rewrite to accommodate custom clients.
- `Add an API endpoint for voting`
  - Adds two handlers, similar to the normal handlers for voting, with the difference being data is returned via json.
- `Fix lint violations`: title.
- `Update route map for vote API`: title.

Feedback is greatly appreciated.