### PR TITLE
Add instructions for review team when resubmitting project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -283,7 +283,10 @@ class ProjectsController < ApplicationController
       return
     end
 
-    if @project.request_recertification!
+    # Save the instructions (for the review team) if provided 
+    instructions = params[:recertification_instructions]
+
+    if @project.request_recertification!(instructions)
       redirect_to project_path(@project), notice: "Re-certification requested! Your project will be reviewed again."
     else
       redirect_to project_path(@project), alert: "Cannot request re-certification for this project."

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -394,11 +394,14 @@ class Project < ApplicationRecord
     !latest_ship_certification.pending?
   end
 
-  def request_recertification!
+  def request_recertification!(instructions=nil)
     return false unless can_request_recertification?
 
     # create a new pending ship certification
-    ship_certifications.create!(judgement: :pending)
+    ship_certifications.create!(
+      judgement: :pending,
+      recertification_instructions: instructions
+    )
   end
 
   def unpaid_ship_events_since_last_payout

--- a/app/models/ship_certification.rb
+++ b/app/models/ship_certification.rb
@@ -2,13 +2,14 @@
 #
 # Table name: ship_certifications
 #
-#  id          :bigint           not null, primary key
-#  judgement   :integer          default("pending"), not null
-#  notes       :text
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  project_id  :bigint           not null
-#  reviewer_id :bigint
+#  id                           :bigint           not null, primary key
+#  judgement                    :integer          default("pending"), not null
+#  notes                        :text
+#  recertification_instructions :text
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  project_id                   :bigint           not null
+#  reviewer_id                  :bigint
 #
 # Indexes
 #

--- a/app/views/admin/ship_certifications/edit.html.erb
+++ b/app/views/admin/ship_certifications/edit.html.erb
@@ -13,6 +13,11 @@
   <% end %>
 </div>
 
+<% if @ship_certification.recertification_instructions.present? %>
+  <div style="color: var(--color-muted); font-size: 1em; font-weight: 600;">Special instructions from the project author:</div>
+  <div class="special-instructions"><%= simple_format(@ship_certification.recertification_instructions) %></div>
+<% end %>
+
 <div class="edit-ship-cert-form">
   <%= render 'form', ship_certification: @ship_certification, current_user: current_user %>
 </div>
@@ -41,5 +46,14 @@
   color: var(--color-text);
   font-size: 1em;
   margin-bottom: 0.2em;
+}
+.special-instructions p {
+  padding: 0.7em 1em;
+  border-radius: 7px;
+  border: 1px solid var(--color-border);
+  background: var(--color-sheet);
+  color: var(--color-text);
+  font-size: 1em;
+  width: 400px;
 }
 </style>

--- a/app/views/projects/_project_card.html.erb
+++ b/app/views/projects/_project_card.html.erb
@@ -305,12 +305,33 @@
                 <p class="text-sm text-red-700 mb-3">
                   Your project didn't get certified. Check the feedback above.
                 </p>
+                <div>
+                  <label for="recertification-instructions-visible-<%= @project.id %>" class="block text-sm font-medium text-gray-700">
+                    Special instructions for the review team (optional):
+                  </label>
+                  <textarea 
+                    id="recertification-instructions-visible-<%= @project.id %>" 
+                    rows="5" 
+                    class="som-horizontal-input mt-1 block w-full text-sm"
+                  ></textarea>
+                </div>
                 <% if @project.can_request_recertification? %>
-                  <%= button_to request_recertification_project_path(@project),
-                      class: "som-button-primary px-4 py-2 text-sm",
-                      data: { confirm: "Request re-certification? Make sure you've fixed the issues mentioned in the feedback above." } do %>
-                    Request Re-certification
+                  <%= form_with url: request_recertification_project_path(@project), method: :post, local: true, id: "recertification-instructions-form-#{@project.id}" do |f| %>
+                    <%= f.text_area :recertification_instructions, id: "recertification-instructions-#{@project.id}", style: "display:none;" %>
                   <% end %>
+                  <button
+                      type="button"
+                      class="som-button-primary px-4 py-2 text-sm mt-4"
+                      data-confirm="Request re-certification? Make sure you've fixed the issues mentioned in the feedback above." 
+                      onclick="
+                        if(confirm(this.dataset.confirm)){
+                          document.getElementById('recertification-instructions-<%= @project.id %>').value =
+                            document.getElementById('recertification-instructions-visible-<%= @project.id %>').value;
+                          document.getElementById('recertification-instructions-form-<%= @project.id %>').submit();
+                        }
+                        return false;
+                      "
+                  >Request Re-certification</button>
                 <% end %>
               </div>
             <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[8.0].define(version: 2025_07_30_182737) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_12_185310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -416,6 +415,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_30_182737) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "recertification_instructions"
     t.index ["project_id", "judgement"], name: "index_ship_certifications_on_project_id_and_judgement"
     t.index ["project_id"], name: "index_ship_certifications_on_project_id"
     t.index ["reviewer_id"], name: "index_ship_certifications_on_reviewer_id"


### PR DESCRIPTION
Allow people to add a message for the review team when resubmitting for certification.

*The project page:*
<img width="948" height="939" alt="Project Page" src="https://github.com/user-attachments/assets/2d901450-20d2-413d-b89e-d11b359ed951" />

*The ship certification dashboard:*
<img width="791" height="329" alt="Dashboard" src="https://github.com/user-attachments/assets/ef9de6a2-812f-4d40-b70d-a0e752ed2d5e" />
