### PR TITLE
Hackatime no longer causes banned users to be unbanned

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -357,8 +357,6 @@ class User < ApplicationRecord
 
     if should_ban && !is_banned
       ban_user!("hackatime_ban")
-    elsif !should_ban && is_banned
-      unban_user!
     end
 
     if projects.empty?


### PR DESCRIPTION
Previously, admins could not only SoM ban someone, as if they were not Hackatime banned, they would be unbanned automatically. I removed the unban function from the Hackatime refresh.