### PR TITLE
Fix regex in strip_formatting method

### DIFF
--- a/app/models/devlog.rb
+++ b/app/models/devlog.rb
@@ -198,7 +198,7 @@ class Devlog < ApplicationRecord
   def strip_formatting(text)
     return "" if text.nil?
 
-    text.gsub(/[\s\n\r\t\*\_\#\~\`\>\<\-\+\.\,\;\:\!\?\(\)\[\]\{\}]/i, "").downcase
+    text.gsub(/[\s\n\r\t\*\_\#\~\`\>\<\-\+\.\,\;\:\!\?\(\)\[\]\{\}\\]/i, "").downcase
   end
 
   def notify_followers_and_stakers


### PR DESCRIPTION
Updated strip_formatting method to include backslash in regex. This makes adding (or removing) a backslash count as editing the formatting of a devlog