### PR TITLE
Switch to easier language colors library

### DIFF
--- a/app/views/admin/ysws_reviews/index.html.erb
+++ b/app/views/admin/ysws_reviews/index.html.erb
@@ -1,4 +1,5 @@
 <body class="adash" style="background: var(--color-background); color: var(--color-text); min-height: 100vh; padding: 2rem;">
+<link rel="stylesheet" href="https://kujitegemea.github.io/language-colors/language-colors.css">
 
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
   <h1>YSWS Reviews
@@ -53,7 +54,7 @@
               <div style="margin-top: 0.5rem; font-size: 0.85em;">
                 <strong>Languages:</strong>
                 <% project.project_language.language_percentages.sort_by { |lang, pct| -pct }.first(3).each_with_index do |(language, percentage), index| %>
-                  <span class="pill <%= "#{language.gsub(/[^A-Za-z0-9]/, '-')}-bg" %>" style="font-size: 0.7em; margin-left: 0.25rem; color: white; text-shadow: 1px 1px 1px rgba(0,0,0,0.5);">
+                  <span class="pill <%= "bg-color-#{language.gsub(/[^A-Za-z0-9]/, '_').downcase}" %>" style="font-size: 0.7em; margin-left: 0.25rem; color: white; text-shadow: 0px 0px 3px rgba(0,0,0,1);">
                     <%= language %> (<%= percentage %>%)
                   </span>
                 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,6 @@
     <%= stylesheet_link_tag "tooltips" %>
     <%= stylesheet_link_tag "balloons", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "tutorial", "data-turbo-track": "reload" %>
-    <link rel="stylesheet" href="https://unpkg.com/github-lang-css@1.0.2/background.css">
     <%= javascript_importmap_tags %>
 
     <script defer data-domain="summer.hackclub.com" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.tagged-events.js"></script>


### PR DESCRIPTION
<img width="428" height="66" alt="Screenshot 2025-09-03 at 13 47 51" src="https://github.com/user-attachments/assets/3c621033-1a26-4ebb-9423-ac030f031b52" />
<img width="716" height="62" alt="Screenshot 2025-09-03 at 13 47 47" src="https://github.com/user-attachments/assets/a5c1d807-7a9b-43b7-a0af-1ca479685a5a" />
<img width="692" height="68" alt="Screenshot 2025-09-03 at 13 47 44" src="https://github.com/user-attachments/assets/9d3e4c2d-d392-4f91-be16-e022a1f9883e" />
<img width="364" height="72" alt="Screenshot 2025-09-03 at 13 47 37" src="https://github.com/user-attachments/assets/de624037-5e48-4446-9001-317e98502f7c" />

Fixes coloring and adds a little more contrast for light pills