### PR TITLE
Fix devlog comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -75,6 +75,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:content)
+    params.require(:comment).permit(:content, :rich_content)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -23,6 +23,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
+  include ActionView::Helpers::SanitizeHelper
+  
   belongs_to :user
   belongs_to :devlog, counter_cache: true
 
@@ -33,6 +35,17 @@ class Comment < ApplicationRecord
 
   def display_content
     content.to_s
+  end
+
+  def formatted_content
+    return content unless rich_content.present?
+
+    data = JSON.parse(rich_content) rescue {}
+    if data["content"].present?
+      sanitize(data["content"], tags: %w[p br strong em a code pre blockquote ul ol li], attributes: %w[href])
+    else
+      content
+    end
   end
 
   private

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="space-y-2">
           <div class="text-xs sm:text-sm md:text-base text-gray-600 break-words overflow-wrap-anywhere pr-2">
-            <%= h(comment.content) %>
+            <%= comment.formatted_content %>
           </div>
           <% if comment.user == current_user %>
             <div class="flex justify-end">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_133553) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_03_171043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -257,6 +257,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_133553) do
     t.jsonb "hackatime_projects_key_snapshot", default: [], null: false
     t.boolean "is_neighborhood_migrated", default: false, null: false
     t.boolean "for_sinkening", default: false, null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_devlogs_on_deleted_at"
     t.index ["project_id"], name: "index_devlogs_on_project_id"
     t.index ["user_id"], name: "index_devlogs_on_user_id"
     t.index ["views_count"], name: "index_devlogs_on_views_count"


### PR DESCRIPTION
Fixes issue [#1013](https://github.com/hackclub/summer-of-making/issues/1013). 

The devlog comments are now rendered as (sanitized) HTML instead of plain text. 

_Before:_
<img width="325" alt="before" src="https://github.com/user-attachments/assets/0f48fede-9346-41ae-9519-a2723a5ec653" />

_After:_
<img width="325" alt="after" src="https://github.com/user-attachments/assets/8b979f90-2b88-4a4c-ae66-ba7aa791f825" />
