### PR TITLE
Voting optimizations

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -264,7 +264,12 @@ class VotesController < ApplicationController
 
     @ship_events = @vote_queue.current_ship_events
 
+    ActiveRecord::Associations::Preloader
+      .new(records: @projects, associations: [ :banner_attachment, { devlogs: [ :user, :file_attachment ] } ])
+      .call
+
     # what in the vibe code did rowan do here before :skulk:
+
     @project_ai_used = {}
     @projects.each do |project|
       ai_used = if project.respond_to?(:ai_used?)

--- a/app/jobs/refill_user_vote_queue_job.rb
+++ b/app/jobs/refill_user_vote_queue_job.rb
@@ -5,6 +5,13 @@ class RefillUserVoteQueueJob < ApplicationJob
   include UniqueJob
 
   def perform(user_id)
-    Rails.logger.info "RefillUserVoteQueueJob is deprecated"
+    user = User.find_by(id: user_id)
+    return unless user
+
+    queue = user.user_vote_queue || user.build_user_vote_queue.tap(&:save!)
+
+    return unless queue.needs_refill?
+
+    queue.refill_queue!(UserVoteQueue::QUEUE_SIZE)
   end
 end


### PR DESCRIPTION
UserVoteQueue: 

1. memoize `current_ship_events` and `voted_ship_event_ids`
2. remove `replace_current_pair!`
3. optimize matchup generation: average time to generate matchup reduced by ~100ms

VotesController:
1. 1-pair sync refill when exhausted + enqueue job (un-deprecated it) when below threshold.
2. Votes#create optimized to only use Record IDs