### PR TITLE
Add caching to map controller & simplify routes

### DIFF
--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -1,16 +1,18 @@
 class MapController < ApplicationController
   before_action :authenticate_user!
   before_action :check_identity_verification
-  include MapHelper
 
   def index
-    @projects_on_map = project_map_data(map_projects_query).to_json
+    @projects_on_map = Cache::MapPointsJob.perform_now
     @placeable_projects = current_user.projects.joins(:ship_events).not_on_map.distinct.order(created_at: :desc)
+
+    respond_to do |format|
+      format.html { @projects_on_map = @projects_on_map.to_json }
+      format.json { render json: { projects: @projects_on_map } }
+    end
   end
 
-  def points
-    render json: { projects: project_map_data(map_projects_query) }
-  end
+  private
 
   def check_identity_verification
     return if current_user&.identity_vault_id.present? && current_verification_status != :ineligible

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -1,30 +1,4 @@
 module MapHelper
-  include ApplicationHelper
-
-  def project_map_data(projects)
-    projects.map do |project|
-      {
-        id: project.id,
-        x: project.x,
-        y: project.y,
-        title: project.title,
-        user_id: project.user_id,
-        devlogs_count: project.devlogs_count,
-        total_time_spent: format_seconds(project.total_seconds_coded),
-        project_path: project_path(project),
-        user: {
-          display_name: project.user.display_name,
-          avatar: url_for(project.user.avatar),
-          favorite_color: project.user.user_profile&.balloon_color
-        }
-      }.compact
-    end
-  end
-
-  def map_projects_query
-    Project.joins(:ship_events).on_map.includes(user: :user_profile).distinct
-  end
-
   def placeable_projects_message(count)
     return "No projects available to place. Ship a project first to add it to the map." if count.zero?
 

--- a/app/jobs/cache/map_points_job.rb
+++ b/app/jobs/cache/map_points_job.rb
@@ -1,0 +1,17 @@
+class Cache::MapPointsJob < ApplicationJob
+  queue_as :literally_whenever
+
+  CACHE_KEY = "map_projects_data"
+  CACHE_DURATION = 1.hour
+
+  def perform(force: false)
+    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_DURATION) do
+      projects = Project.joins(:ship_events)
+                        .on_map
+                        .includes(:devlogs, user: :user_profile)
+                        .distinct
+
+      ::ProjectMapPresenter.collection(projects)
+    end
+  end
+end

--- a/app/presenters/project_map_presenter.rb
+++ b/app/presenters/project_map_presenter.rb
@@ -1,0 +1,47 @@
+# This is based on https://thoughtbot.com/blog/using-the-presenter-pattern-in-ruby-on-rails
+# It's an antipattern to pull out a new abstraction like this, but I'm doing it
+# in this case because the event has 20 days left.
+
+# I strongly encourage not doing this for other cases of messy code,
+# particularly if the event gets extended again. - @msw
+class ProjectMapPresenter
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::DateHelper
+  include ApplicationHelper
+
+  def initialize(project)
+    @project = project
+  end
+
+  def to_h
+    {
+      id: @project.id,
+      x: @project.x,
+      y: @project.y,
+      title: @project.title,
+      user_id: @project.user_id,
+      devlogs_count: @project.devlogs_count,
+      total_time_spent: format_seconds(@project.total_seconds_coded),
+      project_path: project_path(@project),
+      user: user_data
+    }.compact
+  end
+
+  def self.collection(projects)
+    projects.map { |project| new(project).to_h }
+  end
+
+  private
+
+  def user_data
+    {
+      display_name: @project.user.display_name,
+      avatar: avatar_url,
+      favorite_color: @project.user.user_profile&.balloon_color
+    }
+  end
+
+  def avatar_url
+    Rails.application.routes.url_helpers.url_for(@project.user.avatar)
+  end
+end

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -2,7 +2,7 @@
      data-map-projects-value="<%= @projects_on_map %>"
      data-map-user-id-value="<%= current_user.id %>"
      data-map-update-url-value="<%= update_coordinates_project_path(':id') %>"
-     data-map-map-points-url-value="<%= map_points_path %>"
+     data-map-map-points-url-value="<%= map_path(format: :json) %>"
      data-map-unplace-url-value="<%= unplace_coordinates_project_path(':id') %>"
      class="relative w-screen h-[100dvh] overflow-hidden bg-[#41A5E7]">
   <div class="absolute inset-0 bg-[url('/map_sea_background.jpg')] bg-cover bg-center opacity-28 pointer-events-none z-0"></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module Journey
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("app/models/shop_item")
     # config.autoload_paths << Rails.root.join("app/models/shop_item")
+    config.autoload_paths << Rails.root.join("app/presenters")
     config.after_initialize { eager_load! }
 
     # bring in game constants from yaml

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,7 @@ development:
   database: journey_development
 
   # Uncomment this line to use the production database for development! Must have PROD_DATABASE_URL set in the environment.
-  # url: <%= ENV['PROD_DATABASE_URL'] %>
+  url: <%= ENV['PROD_DATABASE_URL'] %>
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -121,3 +121,8 @@ production:
     schedule: every minute
     concurrency: 1
     description: "Sync GitHub language stats for projects under review"
+
+  cache_map_points:
+    class: Cache::MapPointsJob
+    schedule: every 30 minutes
+    args: [ { force: true } ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,8 +251,8 @@ Rails.application.routes.draw do
   get "check_github_readme", to: "projects#check_github_readme"
   get "campfire", to: "campfire#index"
   get "campfire/hackatime_status", to: "campfire#hackatime_status"
+
   get "/map", to: "map#index", as: :map
-  get "/map/points", to: "map#points", as: :map_points
 
   # Global timer session check - must be before projects resource
   get "timer_sessions/active", to: "timer_sessions#global_active"


### PR DESCRIPTION
This simplifies the map data loading and adds it to the cache so we only have to pull new map data points from the db if someone adds a project to the map.