### PR TITLE
Actually allow fraud reviewers to see voting/payouts

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -411,6 +411,8 @@ Rails.application.routes.draw do
         end
       end
       resources :fulfillment_dashboard, only: [ :index ]
+      resources :voting_dashboard, only: [ :index ]
+      resources :payouts_dashboard, only: [ :index ]
       resources :shop_orders do
         collection do
           get :pending
@@ -470,8 +472,6 @@ Rails.application.routes.draw do
       mount Flipper::UI.app(Flipper), at: "flipper"
       # mount_avo
       resources :view_analytics, only: [ :index ]
-      resources :voting_dashboard, only: [ :index ]
-      resources :payouts_dashboard, only: [ :index ]
       resources :ship_reviewer_payout_requests, only: [ :index, :show ] do
         member do
           patch :approve


### PR DESCRIPTION
Based on [this commit](https://github.com/hackclub/summer-of-making/commit/6f57b99a8b44a7a23bfc98178355770b4088f967).

That change only allowed fraud team members to see the buttons, they still would give a 404.