### PR TITLE
Make advent of stickers Slack messages better

### DIFF
--- a/app/services/advent_of_stickers/awarder.rb
+++ b/app/services/advent_of_stickers/awarder.rb
@@ -69,7 +69,7 @@ module AdventOfStickers
         # Channel announce
         channel_id = "C015M4L9AHW"
         if channel_id.present?
-          text = "#{user.display_name} just unlocked today’s sticker: #{target_sticker.name}! :partyparrot:"
+          text = "<!channel> SUPER IMPORTANT MESSAGE!!! #{user.display_name} just unlocked today’s sticker: #{target_sticker.name}! :partyparrot:"
           SendSlackDmJob.perform_later(channel_id, text)
         end
       end


### PR DESCRIPTION
In #summer-of-making the messages for when people get a sticker aren't treated as the unique event that they are, so this PR fixes that. Now, it will send a channel ping stressing the importance of this rare event.