### PR TITLE
Fix Orpheus/Journeypheus z-index issue on /votes/new

### DIFF
--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -272,7 +272,7 @@
   </script>
 </div>
 
-<div id="journey-music" data-turbo-permanent data-controller="music" class="fixed -bottom-28 sm:-bottom-32 -right-12 max-sm:mb-[140px]">
+<div id="journey-music" data-turbo-permanent data-controller="music" class="fixed -bottom-28 sm:-bottom-32 -right-12 z-40 max-sm:mb-[140px]">
   <div data-music-target="speechBubble" class="absolute -top-12 -left-10 2xl:-top-16 2xl:-left-12 p-3 bg-[#F3ECD8] rounded-2xl border-4 border-[#E4DCC6] max-w-[150px] opacity-50">
     <div class="text-sm text-forest font-medium">Click me, please!</div>
   </div>


### PR DESCRIPTION
This PR simply changes the z-index of Journeypheus on the voting page so that it doesn't hide behind other elements (e.g. videos, todo list).

<img width="1920" height="1080" alt="orpheus_zindex" src="https://github.com/user-attachments/assets/3f625cc4-04e6-4c24-bee7-a7e983719009" />
