### PR TITLE
Change Advent of Stickers channel

### DIFF
--- a/app/services/advent_of_stickers/awarder.rb
+++ b/app/services/advent_of_stickers/awarder.rb
@@ -67,7 +67,7 @@ module AdventOfStickers
         end
 
         # Channel announce
-        channel_id = "C015M4L9AHW"
+        channel_id = "C09FEFYGH9R"
         if channel_id.present?
           text = "#{user.display_name} just unlocked today’s sticker: #{target_sticker.name}! :partyparrot:"
           SendSlackDmJob.perform_later(channel_id, text)


### PR DESCRIPTION
https://hackclub.slack.com/archives/C0188CY57PZ/p1758049302998039

A more serious PR this time than the channel ping one, since the sticker messages are clogging up #summer-of-making maybe we should move it to a new channel.