### PR TITLE
Fix issues with migration for recertification instructions

### DIFF
--- a/app/views/admin/ship_certifications/edit.html.erb
+++ b/app/views/admin/ship_certifications/edit.html.erb
@@ -39,10 +39,10 @@
   <% end %>
 </div>
 
-<%# if @ship_certification.recertification_instructions.present? %>
-  <%# <div style="color: var(--color-muted); font-size: 1em; font-weight: 600;">Special instructions from the project author:</div> %>
-  <%# <div class="special-instructions"><%= simple_format(@ship_certification.recertification_instructions) %></div> %>
-<%# end %>
+<% if @ship_certification.try(:recertification_instructions)&.present? %>
+  <div style="color: var(--color-muted); font-size: 1em; font-weight: 600;">Special instructions from the project author:</div>
+  <div class="special-instructions"><%= simple_format(@ship_certification.recertification_instructions) %></div>
+<% end %>
 
 <div class="edit-ship-cert-form">
   <%= render 'form', ship_certification: @ship_certification, current_user: current_user %>

--- a/db/migrate/20250919182647_add_recertification_instructions_to_ship_certifications.rb
+++ b/db/migrate/20250919182647_add_recertification_instructions_to_ship_certifications.rb
@@ -1,0 +1,5 @@
+class AddRecertificationInstructionsToShipCertifications < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ship_certifications, :recertification_instructions, :text unless column_exists?(:ship_certifications, :recertification_instructions)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_16_171231) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_19_182647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/fixtures/ship_certifications.yml
+++ b/test/fixtures/ship_certifications.yml
@@ -4,16 +4,17 @@
 #
 # Table name: ship_certifications
 #
-#  id                    :bigint           not null, primary key
-#  judgement             :integer          default("pending"), not null
-#  notes                 :text
-#  ysws_feedback_reasons :text
-#  ysws_returned_at      :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  project_id            :bigint           not null
-#  reviewer_id           :bigint
-#  ysws_returned_by_id   :bigint
+#  id                           :bigint           not null, primary key
+#  judgement                    :integer          default("pending"), not null
+#  notes                        :text
+#  recertification_instructions :text
+#  ysws_feedback_reasons        :text
+#  ysws_returned_at             :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  project_id                   :bigint           not null
+#  reviewer_id                  :bigint
+#  ysws_returned_by_id          :bigint
 #
 # Indexes
 #


### PR DESCRIPTION
This PR adds a try block for the recertification instructions (so hopefully the site won't break), in the ship_certification dashboard code. Also adds the missing migration file.