### PR TITLE
Fix devlog comments returning a 404 when deleted

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,18 +29,6 @@ class CommentsController < ApplicationController
     end
   end
 
-  private
-
-  def extract_text_from_rich_content(rich_content)
-    json = JSON.parse(rich_content)["json"] rescue nil
-    return "" unless json && json["content"]
-
-    json["content"].flat_map do |node|
-      node["content"]&.map { |inner| inner["text"] } || []
-    end.join(" ").strip
-  end
-
-
   def destroy
     @comment = @devlog.comments.find(params[:id])
     authorize @comment
@@ -69,6 +57,15 @@ class CommentsController < ApplicationController
   end
 
   private
+
+  def extract_text_from_rich_content(rich_content)
+    json = JSON.parse(rich_content)["json"] rescue nil
+    return "" unless json && json["content"]
+
+    json["content"].flat_map do |node|
+      node["content"]&.map { |inner| inner["text"] } || []
+    end.join(" ").strip
+  end
 
   def set_devlog
     @devlog = Devlog.find(params[:devlog_id])


### PR DESCRIPTION
Fixes the 404 error devlog comments return when being deleted. 