### PR TITLE
Revert "Temporarily block ysws review page"

### DIFF
--- a/app/controllers/admin/ysws_reviews_controller.rb
+++ b/app/controllers/admin/ysws_reviews_controller.rb
@@ -4,9 +4,6 @@ module Admin
     skip_before_action :authenticate_admin!
 
     def index
-    # TEMPORARY: Block YSWS reviews to test memory leak
-    render plain: "YSWS Reviews temporarily disabled for memory leak testing", status: 503
-    return
     @filter = params[:filter] || "pending"
     @sort_by = params[:sort_by] || "random"
 


### PR DESCRIPTION
Reverts hackclub/summer-of-making#1178

The suspected leaking from regexes isn't the cause, though it was taking up some memory. Setting this revert PR up so I can easily get it turned back on when ready