### PR TITLE
Fix authorization blocking fraud team from /admin/users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -313,11 +313,14 @@ module Admin
     private
 
     def ensure_authorized_user
+      # Allow admins and fraud team full access
+      return if current_user&.is_admin? || current_user&.fraud_team_member?
+
       # Ship certifiers can only access recertification blocking actions
-      if current_user&.ship_certifier? && !current_user&.is_admin?
+      if current_user&.ship_certifier?
         allowed_actions = %w[show block_recertification unblock_recertification]
         redirect_to(root_path, alert: "whomp whomp") unless allowed_actions.include?(action_name)
-      elsif !(current_user&.is_admin? || current_user&.fraud_team_member?)
+      else
         redirect_to root_path, alert: "whomp whomp"
       end
     end


### PR DESCRIPTION
Fixed authorization logic that was blocking fraud team members from accessing /admin/users.

The issue was that the authorization check evaluated ship_certifier status before checking admin/fraud_team_member status. If a user had both fraud_team_member and ship_certifier permissions, they would be caught by the ship certifier restrictions.

The fix ensures admins and fraud team members get full access with an early return before any ship certifier restrictions are applied.