### PR TITLE
Point landing page to Hack Club Stardance

### DIFF
--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -38,8 +38,8 @@
                 </div>
                 <div class="mt-4 p-4 bg-white/50 rounded-xl border-2 border-som-orange/30">
                   <p class="font-['Fredoka',sans-serif] font-normal text-base sm:text-lg text-[#3a2f25] text-center">
-                    <span class="font-semibold text-som-orange">Hack Club Flavortown</span> - the successor to Summer of Making 2025 - is running from Dec 22 - Apr 30.
-                    <a href="https://flavortown.hackclub.com?ref=som"
+                    <span class="font-semibold text-som-orange">Hack Club Stardance</span> - Hack Club's latest event - is now live!
+                    <a href="https://stardance.hackclub.com/som"
                       class="font-semibold text-som-orange hover:text-[#d14c26] underline decoration-2 underline-offset-2 transition-colors duration-200"
                       target="_blank"
                       rel="noopener noreferrer">Go to website.</a>
@@ -601,8 +601,8 @@
     </div>
     <div class="max-w-xl mx-auto p-4 bg-white/50 rounded-xl border-2 border-som-orange/30">
       <p class="font-['Fredoka',sans-serif] font-normal text-base sm:text-lg text-[#3a2f25] text-center">
-        <span class="font-semibold text-som-orange">Hack Club Flavortown</span> - the successor to Summer of Making 2025 - is running from Dec 22 - Mar 31.
-        <a href="https://flavortown.hackclub.com?ref=som"
+        <span class="font-semibold text-som-orange">Hack Club Stardance</span> - Hack Club's latest event - is now live!
+        <a href="https://stardance.hackclub.com/som"
           class="font-semibold text-som-orange hover:text-[#d14c26] underline decoration-2 underline-offset-2 transition-colors duration-200"
           target="_blank"
           rel="noopener noreferrer">Go to website.</a>


### PR DESCRIPTION
## Summary
Summer of Making has ended. This updates the landing page so its two successor-event call-outs direct visitors to Hack Club Stardance (https://stardance.hackclub.com/som) instead of Flavortown.

## Changes
- app/views/landing/index.html.erb: both Flavortown call-outs (hero + bottom section) now link to https://stardance.hackclub.com/som with updated copy.

?? Generated with [Claude Code](https://claude.com/claude-code)